### PR TITLE
fix: keep saved window size even when saved position is off-screen

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -947,9 +947,24 @@ fn main() {
         .map(|n| format!("{} — MD Preview", n.to_string_lossy()))
         .unwrap_or_else(|| "MD Preview".to_string());
 
-    let geom = load_window_geom()
+    // Restore size always, restore position only if it's still on-screen.
+    // The previous `filter().unwrap_or_else()` threw the whole geometry
+    // away if the saved position was off-screen — e.g. after a monitor
+    // unplug — which silently reverted the window to the default 900x700
+    // even though the user's preferred *size* was a perfectly valid value
+    // to keep. Decouple the two: any saved size is used as-is; the saved
+    // position is replaced with the centered fallback when it would land
+    // off-screen.
+    let saved = load_window_geom();
+    let centered = centered_geom(&event_loop);
+    let (w, h) = saved
+        .map(|g| (g.w, g.h))
+        .unwrap_or((centered.w, centered.h));
+    let (x, y) = saved
         .filter(|g| geom_visible(g, &event_loop))
-        .unwrap_or_else(|| centered_geom(&event_loop));
+        .map(|g| (g.x, g.y))
+        .unwrap_or((centered.x, centered.y));
+    let geom = WindowGeom { x, y, w, h };
 
     let mut window_builder = WindowBuilder::new()
         .with_title(&title)


### PR DESCRIPTION
## Summary

The load logic currently throws the entire saved geometry away if the center of the saved window would land off-screen:

```rust
let geom = load_window_geom()
    .filter(|g| geom_visible(g, &event_loop))
    .unwrap_or_else(|| centered_geom(&event_loop));
```

The visibility check is a worthwhile safety net **for position** — it prevents the window from coming up under a now-unplugged monitor — but the saved **size** has nothing to do with whether the monitor is still connected. Throwing the size away alongside the position is a surprising side effect: the user's window goes back to the launch default after every monitor change (laptop unplug, dock disconnect, display rearrangement, etc.).

Decouple the two:
- Any saved **size** is used as-is.
- Any saved **position** is replaced with the centered fallback only when it would land off-screen.

A missing geometry file still falls back to the centered default for both, same as before.

## Test plan

- [x] Save a geometry, then unplug the monitor it was on → next launch comes up centered at the **saved** size (previously: centered at the launch default)
- [x] Save a geometry on a monitor that is still attached → next launch restores both position and size unchanged
- [x] Delete `~/.config/md-preview/window.geom` → next launch uses the centered default (regression check)
- [x] `cargo build --release` clean