### PR TITLE
让新建与自动保存形成可靠的 Markdown 编辑闭环

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.3.0
+
+- Changed the tab-bar `+` and `Cmd/Ctrl+N` into a dedicated New Markdown flow that creates a `.md` file in the current document folder and opens it directly in source edit.
+- Added 700 ms debounced autosave in source edit mode, so quick edits persist without switching back to preview or pressing Save.
+- Forced pending edits to save before preview, tab activation, tab close, window close, and app quit, including protection against stale autosave acknowledgements.
+- Kept tabs open and editor contents intact when saving fails, with a visible error that explains the affected path.
+- Protected dirty editor contents from external file-change reloads and stopped time-only watcher suppression from hiding real external writes.
+- Verified the native macOS update menu, Sparkle configuration, signed appcast contract, and live GitHub desktop release selection.
+
 ## 1.2.0
 
 - Added a native desktop tab bar for opening multiple Markdown and text documents in one window, with per-tab dirty and missing-file states.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1672,7 +1672,7 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "md-preview"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "image",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-preview"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![App Store](https://img.shields.io/badge/App%20Store-Local%20Markdown%20Preview-blue?logo=appstore)](https://apps.apple.com/cn/app/local-markdown-preview/id6779451523)
 [![Binary size](https://img.shields.io/badge/binary-~5MB-green)](https://github.com/vorojar/md-preview/releases)
 
-> Multiple Markdown files, one lightweight window. Preview, make quick source edits, and resume your tabs without launching a whole IDE.
+> Multiple Markdown files, one lightweight window. Create, preview, and edit with automatic save—without launching a whole IDE.
 
 MD Preview is a fast, local-first Markdown previewer and quick editor built with **Rust** and the system **WebView** on desktop, plus native iOS and Android shells for opening Markdown from Files, WeChat, WeCom, and system share sheets. It does not bundle Chromium, does not require Electron, and keeps all rendering assets offline. Open several local documents as tabs, return to the same active document after restart, or create a Markdown file from Finder on macOS and start typing immediately.
 
@@ -22,7 +22,7 @@ AI coding tools now generate a lot of Markdown: `README.md`, `plan.md`, task spe
 - **Open fast** - native binary, system WebView, no bundled browser runtime.
 - **Stay local** - Markdown, syntax highlighting, math, and diagrams render on your machine.
 - **Keep documents together** - open multiple Markdown and text files in one tabbed window and resume the session later.
-- **Edit without detours** - make a quick source edit in place; on macOS, Finder can create Markdown straight into the editor.
+- **Edit without detours** - create Markdown from the tab bar or Finder, type immediately, and let debounced autosave persist the change.
 - **Follow external edits** - save the file in Vim, VS Code, Cursor, Zed, or anything else; the preview refreshes automatically.
 - **Keep reading clean** - the toolbar only appears on hover, and the start screen gives you Open File plus recent files.
 - **Handle real Markdown** - code blocks, tables, task lists, math formulas, Mermaid diagrams, images, links, and print all work offline.
@@ -78,7 +78,7 @@ md-preview README.md plan.md task.md
 md-preview
 ```
 
-MD Preview accepts `.md` and `.txt` files through drag and drop, the open dialog, recent files, or the command line. Desktop documents open as tabs; opening the same path activates its existing tab. Tab order and the active document are restored across launches, while inactive content stays on disk until selected. Relative images are resolved from the Markdown file's directory, so local documentation folders render naturally.
+MD Preview accepts `.md` and `.txt` files through drag and drop, the open dialog, recent files, or the command line. Desktop documents open as tabs; opening the same path activates its existing tab. Use the tab-bar `+` or `Cmd/Ctrl+N` to create a Markdown file beside the current document and enter source edit immediately. Tab order and the active document are restored across launches, while inactive content stays on disk until selected. Relative images are resolved from the Markdown file's directory, so local documentation folders render naturally.
 
 If a tab's file is moved or deleted, the tab remains visible instead of disappearing silently. Select it to locate the file again or close the tab.
 
@@ -98,13 +98,14 @@ On iPhone and iPad, Local Markdown Preview opens Markdown and plain-text files f
 | Session restore | Restore tab order and the active document after restart without caching inactive document bodies. |
 | Missing files | Moved or deleted files remain as explicit missing tabs with Locate and Close actions. |
 | Finder workflow | On macOS, create Markdown from Finder and start editing it immediately in MD Preview. |
+| Reliable autosave | Source edits save after a short pause and are flushed before preview, tab switches, tab/window close, or quit; save failures keep the tab and text intact. |
 | Start screen | Empty launches show Open File and local recent files, so the app is useful before anything is loaded. |
 | Mobile open | iOS opens Markdown from Files and the share sheet; Android can open Markdown from Files, WeChat, WeCom, and Android share sheets. |
 | Drag and drop | Drop a Markdown file into the window and it opens immediately. |
 | CLI open | `md-preview path/to/file.md` opens directly from a shell. |
 | Find in preview | `Cmd/Ctrl+F` opens a compact search bar for the rendered document. |
 | Live reload | External edits refresh the rendered document automatically. |
-| Inline source edit | `Cmd/Ctrl+E` switches to source mode for quick edits; `Cmd/Ctrl+S` saves. |
+| Inline source edit | `Cmd/Ctrl+E` switches to source mode; edits autosave, while `Cmd/Ctrl+S` forces an immediate save. |
 | Native print | `Cmd/Ctrl+P` opens the platform print dialog and prints only the preview. |
 | Syntax highlighting | highlight.js is embedded offline and injected after first paint. |
 | Math | KaTeX renders `$...$`, `$$...$$`, `\(...\)`, and `\[...\]` on demand. |
@@ -121,6 +122,7 @@ On iPhone and iPad, Local Markdown Preview opens Markdown and plain-text files f
 
 | Shortcut | Action |
 |---|---|
+| `Cmd/Ctrl + N` | Create a Markdown file and enter source edit |
 | `Cmd/Ctrl + O` | Open file |
 | `Cmd/Ctrl + F` | Find in preview |
 | `Cmd/Ctrl + E` | Toggle preview/source edit |

--- a/README_zh.md
+++ b/README_zh.md
@@ -9,7 +9,7 @@
 [![App Store](https://img.shields.io/badge/App%20Store-Local%20Markdown%20Preview-blue?logo=appstore)](https://apps.apple.com/cn/app/local-markdown-preview/id6779451523)
 [![Binary size](https://img.shields.io/badge/binary-~5MB-green)](https://github.com/vorojar/md-preview/releases)
 
-> 多份 Markdown，一个轻量窗口。预览、快速改源码、重启后接着上次的标签继续，不必启动一整个 IDE。
+> 多份 Markdown，一个轻量窗口。直接新建、预览、编辑并自动保存，不必启动一整个 IDE。
 
 MD Preview 是用 **Rust** 和系统 **WebView** 写的本地优先 Markdown 预览与快速编辑工具，桌面端覆盖 macOS、Windows、Linux，手机端提供 iOS 和 Android 原生外壳，方便从文件管理器、微信、企业微信和系统分享面板打开 Markdown。它不打包 Chromium，不依赖 Electron，渲染资源全部离线内置。桌面端可以把多份本地文档放进同一组标签，重启后回到上次活动文档；macOS 上还能从 Finder 新建 Markdown 并立即开始编辑。
 
@@ -22,7 +22,7 @@ AI 编程工具现在会生成大量 Markdown：`README.md`、`plan.md`、任务
 - **打开快**：原生二进制、系统 WebView，不带一份浏览器运行时。
 - **本地渲染**：Markdown、代码高亮、数学公式、Mermaid 图表都在本机完成。
 - **文档放在一起**：在一个标签窗口里打开多份 Markdown 和文本，下次启动继续上次会话。
-- **编辑少绕路**：直接在应用里快速改源码；macOS 上从 Finder 新建 Markdown 后立刻进入编辑。
+- **编辑少绕路**：从标签栏或 Finder 新建 Markdown 后立即输入，停顿片刻就自动保存。
 - **跟随外部编辑**：用 Vim、VS Code、Cursor、Zed 或任何编辑器保存文件，预览自动刷新。
 - **阅读不打扰**：工具栏只在 hover 时出现，空白首页提供打开文件和最近文件，文档始终是主角。
 - **覆盖真实文档**：代码块、表格、任务列表、公式、图表、图片、链接、打印都能离线工作。
@@ -78,7 +78,7 @@ md-preview README.md plan.md task.md
 md-preview
 ```
 
-MD Preview 支持通过拖拽、打开对话框、最近文件或命令行打开 `.md` / `.txt` 文件。桌面端会用标签承载文档；重复打开同一路径时只激活已有标签。重启后恢复标签顺序和活动文档，后台文档正文仍留在磁盘，点击时才加载。相对路径图片会按 Markdown 文件所在目录解析，本地文档目录可以自然渲染。
+MD Preview 支持通过拖拽、打开对话框、最近文件或命令行打开 `.md` / `.txt` 文件。桌面端会用标签承载文档；重复打开同一路径时只激活已有标签。使用标签栏 `+` 或 `Cmd/Ctrl+N` 可在当前文档旁新建 Markdown，并立即进入源码编辑。重启后恢复标签顺序和活动文档，后台文档正文仍留在磁盘，点击时才加载。相对路径图片会按 Markdown 文件所在目录解析，本地文档目录可以自然渲染。
 
 如果标签对应的文件被移动或删除，标签不会静默消失。点击后可以重新定位文件，或者关闭标签。
 
@@ -98,13 +98,14 @@ iPhone 和 iPad 上，Local Markdown Preview 可以从“文件”和 iOS 分享
 | 会话恢复 | 重启后恢复标签顺序和活动文档，但不缓存后台文档正文。 |
 | 缺失文件 | 文件移动或删除后保留缺失标签，提供重新定位和关闭操作。 |
 | Finder 工作流 | macOS 上从 Finder 新建 Markdown，并立即在 MD Preview 里编辑。 |
+| 可靠自动保存 | 源码输入停顿片刻即保存；预览、切换标签、关闭标签/窗口或退出前强制写盘，保存失败时保留标签和编辑内容。 |
 | 启动首页 | 空白启动时显示打开文件和本机最近文件，没加载文档也有明确入口。 |
 | 手机端打开 | iOS 支持从“文件”和分享面板打开 Markdown；Android 支持从文件管理器、微信、企业微信和系统分享面板打开 Markdown。 |
 | 拖拽打开 | 把 Markdown 文件拖进窗口即可打开。 |
 | 命令行打开 | `md-preview path/to/file.md` 直接从 shell 打开。 |
 | 预览搜索 | `Cmd/Ctrl+F` 打开轻量搜索栏，在渲染后的文档内查找。 |
 | 实时刷新 | 外部编辑保存后，预览自动更新。 |
-| 源码编辑 | `Cmd/Ctrl+E` 切到源码模式快速改字，`Cmd/Ctrl+S` 保存。 |
+| 源码编辑 | `Cmd/Ctrl+E` 切到源码模式；编辑会自动保存，`Cmd/Ctrl+S` 可立即保存。 |
 | 原生打印 | `Cmd/Ctrl+P` 打开系统打印对话框，只打印预览内容。 |
 | 代码高亮 | highlight.js 离线内置，首屏之后再注入，不阻塞打开。 |
 | 数学公式 | KaTeX 按需渲染 `$...$`、`$$...$$`、`\(...\)`、`\[...\]`。 |
@@ -121,6 +122,7 @@ iPhone 和 iPad 上，Local Markdown Preview 可以从“文件”和 iOS 分享
 
 | 快捷键 | 作用 |
 |---|---|
+| `Cmd/Ctrl + N` | 新建 Markdown 并进入源码编辑 |
 | `Cmd/Ctrl + O` | 打开文件 |
 | `Cmd/Ctrl + F` | 在预览里搜索 |
 | `Cmd/Ctrl + E` | 切换预览 / 源码编辑 |

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>MD Preview — Multi-Document Markdown Preview and Quick Edit</title>
-<meta name="description" content="Open multiple Markdown files in lightweight tabs, restore your session, preview Mermaid and KaTeX offline, and make quick source edits without launching an IDE. Native builds for macOS, Windows, Linux, iOS, and Android.">
+<meta name="description" content="Create Markdown from the tab bar, edit multiple files in lightweight tabs, and rely on automatic save before switching, closing, or quitting. Native builds for macOS, Windows, Linux, iOS, and Android.">
 <meta name="keywords" content="markdown preview, markdown tabs, multi document markdown, markdown viewer, markdown editor, Finder markdown, session restore, ios markdown viewer, android markdown viewer, AI generated docs, Claude Code markdown, Codex markdown, Cursor markdown, Mermaid preview, KaTeX preview, lightweight markdown app, rust markdown, native markdown viewer, offline markdown, electron alternative, wry, pulldown-cmark">
 <meta name="author" content="vorojar">
 <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="MD Preview">
 <meta property="og:title" content="MD Preview — Multiple Markdown Files, One Lightweight Window">
-<meta property="og:description" content="Keep Markdown documents open in tabs, resume them after restart, and create a new Markdown file from Finder straight into source edit. Rust + system WebView, no Electron.">
+<meta property="og:description" content="Create Markdown from the tab bar, keep documents open across restarts, and edit with reliable automatic save. Rust + system WebView, no Electron.">
 <meta property="og:image" content="https://vorojar.github.io/md-preview/hero.jpg">
 <meta property="og:image:width" content="900">
 <meta property="og:image:height" content="732">
@@ -23,7 +23,7 @@
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="MD Preview — Multiple Markdown Files, One Lightweight Window">
-<meta name="twitter:description" content="Native Markdown tabs, session restore, quick source edit, and a Finder-to-editor workflow on macOS. Rust + system WebView, no Electron.">
+<meta name="twitter:description" content="Native Markdown tabs, instant New Markdown, session restore, and reliable automatic save. Rust + system WebView, no Electron.">
 <meta name="twitter:image" content="https://vorojar.github.io/md-preview/hero.jpg">
 
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>#</text></svg>">
@@ -34,13 +34,13 @@
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "MD Preview",
-  "description": "Native cross-platform Markdown preview app with multi-document tabs, session restore, quick source editing, Finder actions on macOS, offline Mermaid and KaTeX, search, live reload, dark mode, and native print. Built with Rust and the system WebView, with no Electron.",
+  "description": "Native cross-platform Markdown preview app with New Markdown, multi-document tabs, session restore, reliable automatic save, Finder actions on macOS, offline Mermaid and KaTeX, search, live reload, dark mode, and native print. Built with Rust and the system WebView, with no Electron.",
   "url": "https://vorojar.github.io/md-preview/",
   "downloadUrl": "https://github.com/vorojar/md-preview/releases",
   "installUrl": "https://apps.apple.com/cn/app/local-markdown-preview/id6779451523",
   "operatingSystem": "macOS, Windows, Linux, iOS, iPadOS, Android",
   "applicationCategory": "DeveloperApplication",
-  "softwareVersion": "1.2.0",
+  "softwareVersion": "1.3.0",
   "fileSize": "5.1MB",
   "license": "https://opensource.org/licenses/MIT",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -349,9 +349,9 @@ footer a { color: inherit; }
 
 <header class="hero">
   <div class="hero-icon" aria-hidden="true">#</div>
-  <div class="release-badge" data-en="New in v1.2 · Multi-document tabs + Finder workflow" data-zh="v1.2 新功能 · 多文档标签 + Finder 工作流"></div>
+  <div class="release-badge" data-en="New in v1.3 · New Markdown + reliable autosave" data-zh="v1.3 新功能 · 一键新建 + 可靠自动保存"></div>
   <h1>MD Preview</h1>
-  <p class="tagline" data-en="Keep multiple Markdown files open in one lightweight window. Tabs survive restarts, and on macOS a new Finder document opens straight into source edit." data-zh="在一个轻量窗口里同时打开多份 Markdown。标签重启后仍在；macOS 上从 Finder 新建文档后，直接进入源码编辑。"></p>
+  <p class="tagline" data-en="Create Markdown from the tab bar, keep multiple files open across restarts, and edit without worrying whether you clicked Preview before closing." data-zh="从标签栏直接新建 Markdown，多份文件重启后仍在；编辑后即使没点预览，关闭前也会可靠保存。"></p>
   <div class="cta">
     <a class="cta-primary" href="https://github.com/vorojar/md-preview/releases/latest" data-en="Download Desktop" data-zh="下载桌面版"></a>
     <a class="cta-secondary" href="https://apps.apple.com/cn/app/local-markdown-preview/id6779451523" data-en="Get iOS App" data-zh="获取 iOS 版"></a>
@@ -360,7 +360,7 @@ footer a { color: inherit; }
 </header>
 
 <section class="screenshot">
-  <img src="./hero.jpg" alt="MD Preview v1.2 showing multiple Markdown document tabs" loading="eager" width="900" height="732">
+  <img src="./hero.jpg" alt="MD Preview showing multiple Markdown tabs and rendered content" loading="eager" width="900" height="732">
 </section>
 
 <section class="stats">
@@ -388,7 +388,8 @@ footer a { color: inherit; }
   <ul class="workflow-list">
     <li data-en="Open several local Markdown and text files in one window; opening the same path simply activates its tab." data-zh="在一个窗口打开多份本地 Markdown 和文本文件；重复打开同一路径只会激活已有标签。"></li>
     <li data-en="Resume tab order and the active document across launches without caching document bodies." data-zh="重启后恢复标签顺序和活动文档，但不缓存文档正文。"></li>
-    <li data-en="Create Markdown from the macOS Finder menu and start typing immediately in MD Preview." data-zh="从 macOS Finder 菜单新建 Markdown，并立即在 MD Preview 里开始编辑。"></li>
+    <li data-en="Use the tab-bar + or Cmd/Ctrl+N to create Markdown beside the current document and start typing immediately." data-zh="使用标签栏 + 或 Cmd/Ctrl+N 在当前文档旁新建 Markdown，并立即开始输入。"></li>
+    <li data-en="Let edits autosave after a short pause, with a final save before preview, tab/window close, or quit." data-zh="输入停顿片刻即自动保存；预览、关闭标签/窗口或退出前还会强制保存。"></li>
     <li data-en="Preview Mermaid, KaTeX, code, tables, and alerts offline, then print or export a clean PDF." data-zh="离线预览 Mermaid、KaTeX、代码、表格和提示块，再打印或导出干净 PDF。"></li>
   </ul>
 </section>
@@ -416,8 +417,8 @@ footer a { color: inherit; }
   </div>
   <div class="feature">
     <div class="icon">&#128269;</div>
-    <h3 data-en="Live reload" data-zh="实时刷新"></h3>
-    <p data-en="Edit in MD Preview or another editor. Saved changes refresh the rendered document automatically." data-zh="可以直接在 MD Preview 编辑，也可以使用其他编辑器；保存后渲染结果自动刷新。"></p>
+    <h3 data-en="Reliable autosave" data-zh="可靠自动保存"></h3>
+    <p data-en="Edits save after a short pause and flush before switching, closing, or quitting. A failed save keeps the tab and source intact." data-zh="输入停顿片刻即保存，切换、关闭或退出前强制写盘；失败时标签和源码都不会丢。"></p>
   </div>
   <div class="feature">
     <div class="icon">&#128269;</div>

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -93,12 +93,15 @@ if '"w",\n        NSEventModifierFlags::Command' not in src:
     raise SystemExit("macOS Close Tab must keep Cmd+W")
 if "window.__setMissing" not in src or "data-locate-tab" not in src:
     raise SystemExit("missing session files must keep their tab and offer relocation")
+for marker in ("new-file", "AUTOSAVE_DEBOUNCE_MS = 700", "window.__mdPreviewResolveExternalChange", "UserEvent::Quit"):
+    if marker not in src:
+        raise SystemExit(f"desktop New Markdown/autosave contract is missing: {marker}")
 PY
   ran=1
 fi
 
 if [ -f docs/index.html ] && [ -f README.md ] && [ -f README_zh.md ]; then
-  echo "[agent-verify] v1.2 product story"
+  echo "[agent-verify] v1.3 product story"
   python3 - <<'PY'
 from pathlib import Path
 import tomllib
@@ -120,7 +123,12 @@ for marker in ("Desktop tabs", "Session restore", "Finder workflow"):
 for marker in ("桌面标签", "会话恢复", "Finder 工作流"):
     if marker not in readme_zh:
         raise SystemExit(f"README_zh.md is missing v1.2 product marker: {marker}")
-if "What's New" not in src or "resume them across launches" not in src:
+for marker in ("New in v1.3", "Reliable autosave"):
+    if marker not in site:
+        raise SystemExit(f"website is missing v1.3 product marker: {marker}")
+if "Reliable autosave" not in readme or "可靠自动保存" not in readme_zh:
+    raise SystemExit("README files must describe v1.3 reliable autosave")
+if "What's New" not in src or "rely on automatic save" not in src:
     raise SystemExit("macOS About must keep the current product positioning and What's New entry")
 PY
   ran=1

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,15 @@ const DEFAULT_H: f64 = 700.0;
 static APP_DIRTY: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug)]
+struct SelfWriteRecord {
+    at: Instant,
+    path: PathBuf,
+    content: String,
+}
+
+#[derive(Debug)]
 enum UserEvent {
+    NewFile,
     OpenFile,
     OpenPaths(Vec<PathBuf>, bool),
     ActivateTab(u64),
@@ -35,7 +43,8 @@ enum UserEvent {
     CloseActiveTab,
     LocateTab(u64),
     FileChanged(PathBuf), // external change: refresh preview AND textarea
-    FileSaved(PathBuf),   // our own save: refresh preview only, leave textarea cursor alone
+    ExternalChangeResolved(bool),
+    FileSaved(PathBuf), // our own save: refresh preview only, leave textarea cursor alone
     SaveFailed(String),
     DirtyChanged(bool),
     ToggleEdit,
@@ -45,6 +54,7 @@ enum UserEvent {
     UpdateCheckResult(UpdateCheckResult),
     SetTheme(ThemeChoice),
     OpenUrl(&'static str),
+    Quit,
     RecentChanged,
     Ready, // first paint landed: inject hljs now; if bench mode, also exit
 }
@@ -146,6 +156,8 @@ struct Strings {
     close_tab: &'static str,
     btn_edit: &'static str,
     btn_preview: &'static str,
+    btn_new: &'static str,
+    new_filename: &'static str,
     btn_open: &'static str,
     btn_search: &'static str,
     btn_print: &'static str,
@@ -167,6 +179,8 @@ impl Strings {
                 close_tab: "关闭标签",
                 btn_edit: "编辑 (Cmd/Ctrl+E)",
                 btn_preview: "预览 (Cmd/Ctrl+E)",
+                btn_new: "新建 Markdown (Cmd/Ctrl+N)",
+                new_filename: "新建.md",
                 btn_open: "Open File (Cmd/Ctrl+O)",
                 btn_search: "搜索 (Cmd/Ctrl+F)",
                 btn_print: "打印 (Cmd/Ctrl+P)",
@@ -184,6 +198,8 @@ impl Strings {
                 close_tab: "Close Tab",
                 btn_edit: "Edit (Cmd/Ctrl+E)",
                 btn_preview: "Preview (Cmd/Ctrl+E)",
+                btn_new: "New Markdown (Cmd/Ctrl+N)",
+                new_filename: "Untitled.md",
                 btn_open: "Open File (Cmd/Ctrl+O)",
                 btn_search: "Find (Cmd/Ctrl+F)",
                 btn_print: "Print (Cmd/Ctrl+P)",
@@ -1286,7 +1302,7 @@ body.editing #btn-print {{ display: none; }}
   #preview .mdp-table-wrap {{ width: auto; margin: 1em 0; transform: none; overflow: visible; }}
 }}
 	</style></head><body class="{body_class}">
-	<div class="tabbar" id="tabbar"><div class="tabs" id="tabs"></div><button class="tab-open" id="tab-open" type="button" title="{btn_open}" aria-label="{btn_open}">+</button></div>
+	<div class="tabbar" id="tabbar"><div class="tabs" id="tabs"></div><button class="tab-open" id="tab-open" type="button" title="{btn_new}" aria-label="{btn_new}">+</button></div>
 	<div class="toolbar">
 	  <button id="btn-open" title="{btn_open}" aria-label="{btn_open}"></button>
 	  <button id="btn-search" title="{btn_search}" aria-label="{btn_search}"></button>
@@ -1332,6 +1348,9 @@ body.editing #btn-print {{ display: none; }}
 	  var ta = document.getElementById('editor');
 	  var dirty = false;
 	  var activeTabId = 0;
+	  var pendingAutosaveTimer = 0;
+	  var autosavePaused = false;
+	  var AUTOSAVE_DEBOUNCE_MS = 700;
 	  var composingFind = false;
 	  var pendingFindTimer = 0;
 	  var FIND_DEBOUNCE_MS = 300;
@@ -1357,11 +1376,27 @@ body.editing #btn-print {{ display: none; }}
     dirty = d;
     window.ipc.postMessage(d ? 'dirty:1' : 'dirty:0');
   }}
+	  function cancelPendingAutosave() {{
+	    if (!pendingAutosaveTimer) return;
+	    clearTimeout(pendingAutosaveTimer);
+	    pendingAutosaveTimer = 0;
+	  }}
 	  function save() {{
+	    cancelPendingAutosave();
+	    if (!dirty) return;
 	    window.ipc.postMessage('save:' + ta.value);
+	  }}
+	  function scheduleAutosave() {{
+	    cancelPendingAutosave();
+	    if (autosavePaused) return;
+	    pendingAutosaveTimer = setTimeout(function() {{
+	      pendingAutosaveTimer = 0;
+	      if (dirty) save();
+	    }}, AUTOSAVE_DEBOUNCE_MS);
 	  }}
 	  window.__mdPreviewSave = save;
 	  function requestTabAction(action, id) {{
+	    cancelPendingAutosave();
 	    var message = 'tab-action:' + action + ':' + id;
 	    if (dirty) message += '\n' + ta.value;
 	    window.ipc.postMessage(message);
@@ -1371,6 +1406,11 @@ body.editing #btn-print {{ display: none; }}
 	    window.ipc.postMessage('open');
 	  }}
 	  window.__mdPreviewOpenFile = openFile;
+	  function newFile() {{
+	    if (inEdit()) leaveEdit();
+	    window.ipc.postMessage('new-file');
+	  }}
+	  window.__mdPreviewNewFile = newFile;
 	  function showFind() {{
 	    if (document.body.classList.contains('empty')) return;
 	    if (inEdit()) return;
@@ -1546,7 +1586,7 @@ body.editing #btn-print {{ display: none; }}
   }};
 
 	  btnOpen.addEventListener('click', openFile);
-	  tabOpen.addEventListener('click', openFile);
+	  tabOpen.addEventListener('click', newFile);
 	  btnSearch.addEventListener('click', showFind);
 	  document.addEventListener('click', function(e) {{
 	    var closeTab = e.target && e.target.closest ? e.target.closest('[data-close-tab]') : null;
@@ -1604,7 +1644,7 @@ body.editing #btn-print {{ display: none; }}
     // WebView::print() calls the right native API on each platform.
     setTimeout(function(){{ window.ipc.postMessage('print'); }}, 0);
   }});
-  ta.addEventListener('input', function() {{ setDirty(true); autoResize(); }});
+	  ta.addEventListener('input', function() {{ setDirty(true); scheduleAutosave(); autoResize(); }});
   window.addEventListener('resize', function() {{ if (inEdit()) autoResize(); }});
 
   document.addEventListener('keydown', function(e) {{
@@ -1613,6 +1653,11 @@ body.editing #btn-print {{ display: none; }}
 	    e.preventDefault();
 	    requestTabAction('close', activeTabId);
 	  }}
+	  return;
+	}}
+	if ((e.metaKey || e.ctrlKey) && (e.key === 'n' || e.key === 'N')) {{
+	  e.preventDefault();
+	  newFile();
 	  return;
 	}}
     if ((e.metaKey || e.ctrlKey) && (e.key === 'r' || e.key === 'R')) {{
@@ -1672,7 +1717,22 @@ body.editing #btn-print {{ display: none; }}
     if (baseHref) base.setAttribute('href', baseHref);
     else base.removeAttribute('href');
   }};
-	window.__markSaved = function() {{ setDirty(false); }};
+	window.__markSaved = function(savedRaw) {{
+	  if (typeof savedRaw === 'string' && ta.value !== savedRaw) {{
+	    window.ipc.postMessage('dirty:1');
+	    return;
+	  }}
+	  autosavePaused = false;
+	  setDirty(false);
+	}};
+	window.__mdPreviewPauseAutosave = function() {{
+	  cancelPendingAutosave();
+	  autosavePaused = true;
+	}};
+	window.__mdPreviewResolveExternalChange = function() {{
+	  cancelPendingAutosave();
+	  window.ipc.postMessage('external-change:' + (dirty ? 'dirty' : 'clean'));
+	}};
 	window.__setTabs = function(tabs) {{
 	  tabs = Array.isArray(tabs) ? tabs : [];
 	  tabsEl.textContent = '';
@@ -1717,9 +1777,10 @@ body.editing #btn-print {{ display: none; }}
 	    document.body.classList.remove('missing');
 	    hideFind();
 	    window.__setBaseHref(baseHref);
-    window.__setPreview(previewHtml, needsMath, needsMermaid);
+	    window.__setPreview(previewHtml, needsMath, needsMermaid);
     if (!inEdit() || !dirty) {{
-      ta.value = rawMd;
+	      autosavePaused = false;
+	      ta.value = rawMd;
       setDirty(false);
       if (inEdit()) autoResize();
     }}
@@ -1727,6 +1788,12 @@ body.editing #btn-print {{ display: none; }}
 	  window.__setEmptyPreview = function(previewHtml) {{
 	    document.body.classList.add('empty');
 	    document.body.classList.remove('missing');
+	    document.body.classList.remove('editing');
+	    btnToggle.innerHTML = ICON_EDIT;
+	    btnToggle.title = L_EDIT;
+	    btnToggle.setAttribute('aria-label', L_EDIT);
+	    cancelPendingAutosave();
+	    autosavePaused = false;
 	    hideFind();
 	    window.__setBaseHref('');
 	    document.getElementById('preview').innerHTML = previewHtml;
@@ -1739,6 +1806,10 @@ body.editing #btn-print {{ display: none; }}
 	    document.body.classList.add('missing');
 	    document.body.classList.remove('editing');
 	    btnToggle.innerHTML = ICON_EDIT;
+	    btnToggle.title = L_EDIT;
+	    btnToggle.setAttribute('aria-label', L_EDIT);
+	    cancelPendingAutosave();
+	    autosavePaused = false;
 	    hideFind();
 	    window.__setBaseHref('');
 	    document.getElementById('preview').innerHTML = previewHtml;
@@ -1781,6 +1852,7 @@ window.__mdPreviewInstallUpdateCheck({{
         preview_html = preview_html,
         raw_md_escaped = html_escape_ta(raw_md),
         btn_open = s.btn_open,
+        btn_new = s.btn_new,
         btn_search = s.btn_search,
         btn_edit = s.btn_edit,
         btn_preview = s.btn_preview,
@@ -2232,6 +2304,66 @@ mod tests {
     }
 
     #[test]
+    fn page_separates_new_file_from_open_and_debounces_autosave() {
+        let strings = Strings::for_lang(Lang::En);
+        let page = build_page(
+            &md_to_html("# Hello"),
+            "# Hello",
+            None,
+            EnhanceFlags::default(),
+            &strings,
+            false,
+            true,
+        );
+
+        assert!(page.contains("window.ipc.postMessage('new-file')"));
+        assert!(page.contains("tabOpen.addEventListener('click', newFile)"));
+        assert!(!page.contains("tabOpen.addEventListener('click', openFile)"));
+        assert!(page.contains("AUTOSAVE_DEBOUNCE_MS = 700"));
+        assert!(page.contains("pendingAutosaveTimer = setTimeout"));
+        assert!(page.contains("window.__markSaved = function(savedRaw)"));
+        assert!(page.contains("window.__mdPreviewResolveExternalChange"));
+        assert!(page.contains("'external-change:' + (dirty ? 'dirty' : 'clean')"));
+        assert!(page.contains("(e.key === 'n' || e.key === 'N')"));
+    }
+
+    #[test]
+    fn closing_the_last_editing_tab_restores_the_empty_preview() {
+        let strings = Strings::for_lang(Lang::En);
+        let page = build_page(
+            &md_to_html("# Hello"),
+            "# Hello",
+            None,
+            EnhanceFlags::default(),
+            &strings,
+            false,
+            true,
+        );
+        let empty_start = page.find("window.__setEmptyPreview = function").unwrap();
+        let missing_start = page.find("window.__setMissing = function").unwrap();
+        let empty_handler = &page[empty_start..missing_start];
+
+        assert!(empty_handler.contains("document.body.classList.remove('editing')"));
+        assert!(empty_handler.contains("btnToggle.innerHTML = ICON_EDIT"));
+    }
+
+    #[test]
+    fn new_markdown_path_keeps_markdown_extensions_and_replaces_other_extensions() {
+        assert_eq!(
+            normalize_new_markdown_path(PathBuf::from("/tmp/plan")),
+            PathBuf::from("/tmp/plan.md")
+        );
+        assert_eq!(
+            normalize_new_markdown_path(PathBuf::from("/tmp/plan.markdown")),
+            PathBuf::from("/tmp/plan.markdown")
+        );
+        assert_eq!(
+            normalize_new_markdown_path(PathBuf::from("/tmp/plan.txt")),
+            PathBuf::from("/tmp/plan.md")
+        );
+    }
+
+    #[test]
     fn page_expands_multi_column_tables() {
         let strings = Strings::for_lang(Lang::En);
         let page = build_page(
@@ -2335,6 +2467,31 @@ mod tests {
         .add_path(PathBuf::from("/tmp/other.md"));
 
         assert!(!event_should_reload_file(&ev, &target));
+    }
+
+    #[test]
+    fn self_write_suppression_checks_disk_content_not_only_time() {
+        let dir = temp_test_dir("self-write-suppression");
+        let path = dir.join("note.md");
+        fs::write(&path, "saved by app").unwrap();
+        let record = SelfWriteRecord {
+            at: Instant::now(),
+            path: path.clone(),
+            content: "saved by app".to_string(),
+        };
+
+        assert!(self_write_still_matches_disk(Some(&record), &path));
+
+        fs::write(&path, "external edit").unwrap();
+        assert!(!self_write_still_matches_disk(Some(&record), &path));
+    }
+
+    #[test]
+    fn external_change_protection_uses_dirty_state_from_either_side() {
+        assert!(!should_protect_external_change(false, false));
+        assert!(should_protect_external_change(true, false));
+        assert!(should_protect_external_change(false, true));
+        assert!(should_protect_external_change(true, true));
     }
 
     #[test]
@@ -2504,6 +2661,10 @@ fn macos_menu_controller_class() -> &'static objc2::runtime::AnyClass {
         send_macos_menu_event(UserEvent::OpenFile);
     }
 
+    extern "C" fn new_file(_: &AnyObject, _: Sel, _: &AnyObject) {
+        send_macos_menu_event(UserEvent::NewFile);
+    }
+
     extern "C" fn close_tab(_: &AnyObject, _: Sel, _: &AnyObject) {
         send_macos_menu_event(UserEvent::CloseActiveTab);
     }
@@ -2522,6 +2683,10 @@ fn macos_menu_controller_class() -> &'static objc2::runtime::AnyClass {
 
     extern "C" fn check_updates(_: &AnyObject, _: Sel, _: &AnyObject) {
         send_macos_menu_event(UserEvent::CheckUpdates);
+    }
+
+    extern "C" fn quit(_: &AnyObject, _: Sel, _: &AnyObject) {
+        send_macos_menu_event(UserEvent::Quit);
     }
 
     extern "C" fn open_website(_: &AnyObject, _: Sel, _: &AnyObject) {
@@ -2606,7 +2771,7 @@ fn macos_menu_controller_class() -> &'static objc2::runtime::AnyClass {
         alert.setAlertStyle(NSAlertStyle::Informational);
         alert.setMessageText(&NSString::from_str("MD Preview"));
         alert.setInformativeText(&NSString::from_str(&format!(
-            "Version {}\n\nOpen multiple local Markdown files in lightweight tabs, resume them across launches, and make quick source edits without opening an IDE.",
+            "Version {}\n\nCreate Markdown from the tab bar, edit several local documents in lightweight tabs, and rely on automatic save when switching, closing, or quitting.",
             env!("CARGO_PKG_VERSION")
         )));
 
@@ -2657,6 +2822,7 @@ fn macos_menu_controller_class() -> &'static objc2::runtime::AnyClass {
                 sel!(mdPreviewOpenFile:),
                 open_file as extern "C" fn(_, _, _),
             );
+            builder.add_method(sel!(mdPreviewNewFile:), new_file as extern "C" fn(_, _, _));
             builder.add_method(
                 sel!(mdPreviewCloseTab:),
                 close_tab as extern "C" fn(_, _, _),
@@ -2674,6 +2840,7 @@ fn macos_menu_controller_class() -> &'static objc2::runtime::AnyClass {
                 sel!(mdPreviewCheckUpdates:),
                 check_updates as extern "C" fn(_, _, _),
             );
+            builder.add_method(sel!(mdPreviewQuit:), quit as extern "C" fn(_, _, _));
             builder.add_method(
                 sel!(mdPreviewOpenWebsite:),
                 open_website as extern "C" fn(_, _, _),
@@ -2799,11 +2966,12 @@ fn install_macos_menu(proxy: EventLoopProxy<UserEvent>, theme: ThemeChoice) {
         mtm,
     ));
     app_menu.addItem(&NSMenuItem::separatorItem(mtm));
-    app_menu.addItem(&item(
+    app_menu.addItem(&command_item(
         "Quit MD Preview",
-        Some(sel!(terminate:)),
+        sel!(mdPreviewQuit:),
         "q",
         NSEventModifierFlags::Command,
+        controller,
         mtm,
     ));
     let app_menu_item = item("MD Preview", None, "", NSEventModifierFlags::empty(), mtm);
@@ -2812,6 +2980,14 @@ fn install_macos_menu(proxy: EventLoopProxy<UserEvent>, theme: ThemeChoice) {
 
     let file_menu = menu("File", mtm);
     file_menu.setAutoenablesItems(false);
+    file_menu.addItem(&command_item(
+        "New Markdown...",
+        sel!(mdPreviewNewFile:),
+        "n",
+        NSEventModifierFlags::Command,
+        controller,
+        mtm,
+    ));
     file_menu.addItem(&command_item(
         "Open...",
         sel!(mdPreviewOpenFile:),
@@ -3348,7 +3524,7 @@ fn is_supported_document(path: &Path) -> bool {
 fn install_file_watcher(
     holder: &Arc<Mutex<Option<notify::RecommendedWatcher>>>,
     proxy: &EventLoopProxy<UserEvent>,
-    last_self_write: &Arc<Mutex<Option<Instant>>>,
+    last_self_write: &Arc<Mutex<Option<SelfWriteRecord>>>,
     path: Option<PathBuf>,
 ) {
     let mut current = holder.lock().unwrap();
@@ -3363,12 +3539,8 @@ fn install_file_watcher(
     if let Ok(mut watcher) = notify::recommended_watcher(move |result: Result<Event, _>| {
         if let Ok(event) = result {
             if event_should_reload_file(&event, &callback_path) {
-                let suppress = last_self_write
-                    .lock()
-                    .unwrap()
-                    .map(|time| time.elapsed() < Duration::from_millis(500))
-                    .unwrap_or(false);
-                if !suppress {
+                let last_self_write = last_self_write.lock().unwrap();
+                if !self_write_still_matches_disk(last_self_write.as_ref(), &callback_path) {
                     let _ = proxy.send_event(UserEvent::FileChanged(callback_path.clone()));
                 }
             }
@@ -3379,6 +3551,21 @@ fn install_file_watcher(
             *current = Some(watcher);
         }
     }
+}
+
+fn self_write_still_matches_disk(record: Option<&SelfWriteRecord>, path: &Path) -> bool {
+    let Some(record) = record else {
+        return false;
+    };
+    record.path == path
+        && record.at.elapsed() < Duration::from_millis(500)
+        && fs::read(path)
+            .map(|content| content == record.content.as_bytes())
+            .unwrap_or(false)
+}
+
+fn should_protect_external_change(webview_dirty: bool, session_dirty: bool) -> bool {
+    webview_dirty || session_dirty
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -3431,6 +3618,23 @@ fn create_finder_file(folder: &Path, kind: &str) -> std::io::Result<PathBuf> {
     }
     fs::write(&path, contents)?;
     Ok(path)
+}
+
+fn normalize_new_markdown_path(mut path: PathBuf) -> PathBuf {
+    let is_markdown = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| {
+            matches!(
+                extension.to_ascii_lowercase().as_str(),
+                "md" | "markdown" | "mdown" | "mkd"
+            )
+        })
+        .unwrap_or(false);
+    if !is_markdown {
+        path.set_extension("md");
+    }
+    path
 }
 
 fn open_terminal(folder: &Path) -> bool {
@@ -3763,7 +3967,7 @@ fn main() {
     persist_session(&initial_session);
     let document_session = Arc::new(Mutex::new(initial_session));
     let enhance_flags: Arc<Mutex<EnhanceFlags>> = Arc::new(Mutex::new(initial_flags));
-    let last_self_write: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
+    let last_self_write: Arc<Mutex<Option<SelfWriteRecord>>> = Arc::new(Mutex::new(None));
     let session_for_ipc = Arc::clone(&document_session);
     let recent_files_for_ipc = Arc::clone(&recent_files);
     let last_self_write_for_ipc = Arc::clone(&last_self_write);
@@ -3802,7 +4006,9 @@ fn main() {
         })
         .with_ipc_handler(move |msg| {
             let body = msg.body();
-            if body == "open" {
+            if body == "new-file" {
+                let _ = proxy_for_ipc.send_event(UserEvent::NewFile);
+            } else if body == "open" {
                 let _ = proxy_for_ipc.send_event(UserEvent::OpenFile);
             } else if let Some(index) = body.strip_prefix("open-recent:") {
                 if let Ok(index) = index.parse::<usize>() {
@@ -3836,7 +4042,11 @@ fn main() {
                     let Some(path) = path else {
                         return;
                     };
-                    *last_self_write_for_ipc.lock().unwrap() = Some(Instant::now());
+                    *last_self_write_for_ipc.lock().unwrap() = Some(SelfWriteRecord {
+                        at: Instant::now(),
+                        path: path.clone(),
+                        content: content.to_string(),
+                    });
                     match fs::write(&path, content) {
                         Ok(()) => {
                             let _ = proxy_for_ipc.send_event(UserEvent::FileSaved(path));
@@ -3867,6 +4077,10 @@ fn main() {
                 let _ = proxy_for_ipc.send_event(UserEvent::DirtyChanged(true));
             } else if body == "dirty:0" {
                 let _ = proxy_for_ipc.send_event(UserEvent::DirtyChanged(false));
+            } else if body == "external-change:dirty" {
+                let _ = proxy_for_ipc.send_event(UserEvent::ExternalChangeResolved(true));
+            } else if body == "external-change:clean" {
+                let _ = proxy_for_ipc.send_event(UserEvent::ExternalChangeResolved(false));
             } else if body == "print" {
                 let _ = proxy_for_ipc.send_event(UserEvent::Print);
             } else if body == "ready" {
@@ -3937,7 +4151,11 @@ fn main() {
                     .active()
                     .map(|tab| tab.path.clone());
                 if let Some(path) = path {
-                    *last_self_write_for_ipc.lock().unwrap() = Some(Instant::now());
+                    *last_self_write_for_ipc.lock().unwrap() = Some(SelfWriteRecord {
+                        at: Instant::now(),
+                        path: path.clone(),
+                        content: content.to_string(),
+                    });
                     match fs::write(&path, content) {
                         Ok(()) => {
                             let _ = proxy_for_ipc.send_event(UserEvent::FileSaved(path));
@@ -4024,11 +4242,49 @@ fn main() {
 
     let mut loaded_enhancers = EnhanceFlags::default();
     let mut pending_window_close = false;
+    let mut warned_external_change: Option<PathBuf> = None;
+    let mut pending_external_change: Option<PathBuf> = None;
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
         match event {
+            TaoEvent::UserEvent(UserEvent::NewFile) => {
+                if session_for_event
+                    .lock()
+                    .unwrap()
+                    .active()
+                    .map(|tab| tab.dirty)
+                    .unwrap_or(false)
+                {
+                    let _ = webview.evaluate_script(
+                        "if(window.__mdPreviewNewFile)window.__mdPreviewNewFile();",
+                    );
+                    return;
+                }
+                let current_dir = session_for_event
+                    .lock()
+                    .unwrap()
+                    .active()
+                    .and_then(|tab| tab.path.parent().map(Path::to_path_buf));
+                let mut dialog = rfd::FileDialog::new()
+                    .add_filter("Markdown", &["md", "markdown", "mdown", "mkd"])
+                    .set_file_name(strings.new_filename);
+                if let Some(current_dir) = current_dir {
+                    dialog = dialog.set_directory(current_dir);
+                }
+                if let Some(path) = dialog.save_file() {
+                    let path = normalize_new_markdown_path(path);
+                    match fs::write(&path, "") {
+                        Ok(()) => {
+                            let _ = proxy.send_event(UserEvent::OpenPaths(vec![path], true));
+                        }
+                        Err(error) => {
+                            show_warning_dialog("Could Not Create File", &error.to_string());
+                        }
+                    }
+                }
+            }
             TaoEvent::UserEvent(UserEvent::OpenFile) => {
                 if session_for_event
                     .lock()
@@ -4156,8 +4412,43 @@ fn main() {
                 }
             }
             TaoEvent::UserEvent(UserEvent::FileChanged(path)) => {
+                if session_for_event
+                    .lock()
+                    .unwrap()
+                    .active()
+                    .map(|tab| tab.path.as_path())
+                    == Some(path.as_path())
+                {
+                    pending_external_change = Some(path);
+                    let _ = webview.evaluate_script(
+                        "if(window.__mdPreviewResolveExternalChange)window.__mdPreviewResolveExternalChange();",
+                    );
+                }
+            }
+            TaoEvent::UserEvent(UserEvent::ExternalChangeResolved(webview_dirty)) => {
+                let Some(path) = pending_external_change.take() else {
+                    return;
+                };
                 let mut session = session_for_event.lock().unwrap();
                 if session.active().map(|tab| tab.path.as_path()) == Some(path.as_path()) {
+                    let session_dirty = session.active().map(|tab| tab.dirty).unwrap_or(false);
+                    if should_protect_external_change(webview_dirty, session_dirty) {
+                        if let Some(tab) = session.active_mut() {
+                            tab.dirty = true;
+                        }
+                        APP_DIRTY.store(true, Ordering::SeqCst);
+                        let _ = webview.evaluate_script(
+                            "if(window.__mdPreviewPauseAutosave)window.__mdPreviewPauseAutosave();",
+                        );
+                        if warned_external_change.as_ref() != Some(&path) {
+                            show_warning_dialog(
+                                "File Changed on Disk",
+                                "Automatic saving is paused and your edits are still in the editor. Press Cmd/Ctrl+S to replace the disk version, or reopen the file to keep the external version.",
+                            );
+                            warned_external_change = Some(path);
+                        }
+                        return;
+                    }
                     render_active_document(
                         &webview,
                         &window,
@@ -4171,6 +4462,9 @@ fn main() {
                 }
             }
             TaoEvent::UserEvent(UserEvent::FileSaved(path)) => {
+                if warned_external_change.as_ref() == Some(&path) {
+                    warned_external_change = None;
+                }
                 let mut session = session_for_event.lock().unwrap();
                 let active_matches = session.active().map(|tab| tab.path.as_path()) == Some(path.as_path());
                 if let Some(tab) = session.tabs.iter_mut().find(|tab| tab.path == path) {
@@ -4184,10 +4478,11 @@ fn main() {
                         let flags = enhance_flags_for(&raw);
                         *enhance_flags.lock().unwrap() = flags;
                         let _ = webview.evaluate_script(&format!(
-                            "if(window.__setPreview)window.__setPreview('{}', {}, {});if(window.__markSaved)window.__markSaved();",
+                            "if(window.__setPreview)window.__setPreview('{}', {}, {});if(window.__markSaved)window.__markSaved('{}');",
                             escape_js(&html),
                             flags.math,
-                            flags.mermaid
+                            flags.mermaid,
+                            escape_js(&raw)
                         ));
                         for script in build_enhancer_bootstrap(flags, loaded_enhancers) {
                             let _ = webview.evaluate_script(&script);
@@ -4276,6 +4571,18 @@ fn main() {
                     );
                 }
             },
+            TaoEvent::UserEvent(UserEvent::Quit) => {
+                if APP_DIRTY.load(Ordering::SeqCst) && !pending_window_close {
+                    pending_window_close = true;
+                    let _ = webview.evaluate_script(
+                        "if(window.__mdPreviewSave)window.__mdPreviewSave();",
+                    );
+                } else if !pending_window_close {
+                    save_window_geom(&window);
+                    persist_session(&session_for_event.lock().unwrap());
+                    *control_flow = ControlFlow::Exit;
+                }
+            }
             TaoEvent::UserEvent(UserEvent::SetTheme(choice)) => {
                 save_theme_choice(choice);
                 window.set_theme(choice.tao_theme());

--- a/task.md
+++ b/task.md
@@ -1,4 +1,58 @@
-# 当前任务：v1.2.0 官网、README、About 与社区补发
+# 当前任务：新建 Markdown、可靠自动保存与 v1.3.0 发布
+
+## 目标
+
+- 标签栏 `+` 不再重复“打开文件”，改为新建 Markdown；选择保存位置后创建新标签并直接进入编辑。
+- 编辑内容停止输入后自动保存；预览、切换标签、关闭标签、关闭窗口和退出应用前都强制刷新待保存内容。
+- 保存失败时不关闭、不切换、不丢编辑内容，并给出明确错误。
+- 检查应用内 GitHub Release 查询、平台资产选择、Sparkle appcast 与签名更新入口，确保 v1.3.0 发布后可被旧版本发现。
+- 完成单测、完整验证、真实 macOS UI、签名、公证、Gatekeeper、Release assets 与应用内更新闭环后发布 v1.3.0。
+
+## 非目标
+
+- 不实现内存态“未命名文档”、草稿云同步、富文本编辑或文件重命名。
+- 不改变 Finder 右键 Text / JSON / HTML 的行为，也不改移动端单文档预览流程。
+- 不提交 App Store Review、推广资料、AGENTS.md 及其他既有未提交内容。
+
+## 验收场景
+
+- [x] `+` 与 `Cmd/Ctrl+N` 打开新建 Markdown 保存面板；默认目录跟随当前文档，确认后创建 `.md` 标签并聚焦编辑器；取消时不创建文件或标签。
+- [x] 文件夹按钮与 `Cmd/Ctrl+O` 仍只打开已有文件，和 `+` 语义不重复。
+- [x] 输入停止约 700ms 后内容自动落盘，标签 dirty 状态恢复为已保存；`Cmd/Ctrl+S` 仍立即保存。
+- [x] 未点击“预览”时，切换标签、标签 `×`、`Cmd/Ctrl+W`、窗口关闭与 macOS `Cmd+Q` 都保存成功；重开文件内容存在。
+- [x] 保存失败会阻止切换或关闭，编辑器内容和 dirty 状态保留，用户可修复后重试。
+- [x] 外部文件变化不会被待保存编辑静默覆盖；自写 watcher 事件不会破坏光标或正文。
+- [x] GitHub Release 查询忽略 mobile、draft 与 prerelease，能选择正确平台资产；最新版显示“已是最新”，新版本走受信 URL 与原生更新入口。
+- [x] `cargo test`、`cargo check`、`./scripts/verify.sh` 与真实 macOS UI 全部通过；三平台 CI 等待 PR。
+- [ ] macOS DMG 及内部 app/appex 完成 Developer ID 签名、公证、staple、Gatekeeper 与 Sparkle appcast 验证；Release 正文来自 CHANGELOG。
+
+## 最小验证命令
+
+```bash
+cargo test
+cargo check
+./scripts/verify.sh
+./bundle.sh
+codesign --verify --deep --strict --verbose=2 "target/MD Preview.app"
+```
+
+## 风险与假设
+
+- MD Preview 当前所有标签都是文件背书；新建流程使用保存面板先确定路径，避免引入无法恢复的内存草稿。
+- 自动保存会增加写盘频率，必须去抖并继续抑制自写 watcher；外部修改与本地 dirty 冲突时以不覆盖用户编辑为优先。
+- 正常退出保存需要覆盖 macOS `Cmd+Q` 真实路径，不能只依据窗口关闭代码推断。
+
+## 当前验证记录
+
+- TDD：新建扩展名、关闭最后编辑标签、外部变化决策与自写事件内容核对均经历失败测试后修复，当前相关测试已通过。
+- 真实 UI：`+`/`Cmd+N` 新建并进入编辑、取消不建文件、700ms 自动保存、`Cmd+W`、红色窗口关闭与 `Cmd+Q` 写盘均通过。
+- 失败恢复：只读文件显示 `Permission denied`，阻止关闭并保留内容；恢复权限后 `Cmd+S` 写盘通过。
+- 更新检查：`verify-sparkle-update.sh` 通过；线上最新桌面版为 `v1.2.0`，平台资产与 `appcast.xml` 完整；应用菜单显示 `MD Preview Is Up to Date / 1.2.0`。
+- 完整验证：`scripts/verify.sh` 通过，包含 33 个 Rust 测试、桌面搜索/锚点、Sparkle、Windows updater、iOS build、Android debug/release、移动渲染与 release readiness。
+
+---
+
+# 已完成任务：v1.2.0 官网、README、About 与社区补发
 
 ## 补发目标
 


### PR DESCRIPTION
## 目标

- 将标签栏 `+` / `Cmd/Ctrl+N` 改为新建 Markdown，并直接进入源码编辑
- 增加 700ms 自动保存，以及切换标签、关闭标签/窗口、退出前强制保存
- 保存失败时阻止关闭并保留编辑内容；加强外部写入冲突保护
- 同步 v1.3.0 的 CHANGELOG、官网、README、About 与更新验收

## 验证

- `cargo test`：33 passed
- `cargo check`：通过
- `./scripts/verify.sh`：通过（桌面、Sparkle、Windows updater、iOS、Android、移动渲染）
- 真实 macOS UI：新建/取消、自动保存、Cmd+W、窗口关闭、Cmd+Q、只读失败与恢复、应用内更新检查均通过
- 当前线上更新菜单显示 `MD Preview Is Up to Date / 1.2.0`

## 工作区边界

仅提交本功能相关 9 个文件；未包含现有 AGENTS、App Store Review、推广与其他用户未提交内容。