### PR TITLE
feat(android): remember reading position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added per-document reading-position persistence on Android, including recent cached documents and normalized restoration after deferred Markdown rendering changes the page height.
+
 ## 1.4.0
 
 - Added local Markdown and text document navigation: relative and absolute file links now open or activate an MD Preview tab, while missing or unsupported local targets stay on the current preview.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The notarized macOS app includes a Finder extension. After dragging `MD Preview.
 
 Right-click inside a Finder folder to create Markdown, text, JSON, or HTML files, copy the folder path, or open the folder in Terminal. **New Markdown** creates a non-conflicting filename and opens it directly in MD Preview's source editor.
 
-On iPhone and iPad, Local Markdown Preview opens Markdown and plain-text files from Files and the iOS share sheet. On Android, MD Preview appears in the system "Open with" and share flows for Markdown files. Recent files are cached privately inside the app, so files opened from temporary providers such as WeChat or WeCom remain available later; stale recent entries are removed safely instead of crashing.
+On iPhone and iPad, Local Markdown Preview opens Markdown and plain-text files from Files and the iOS share sheet. On Android, MD Preview appears in the system "Open with" and share flows for Markdown files. Recent files are cached privately inside the app, so files opened from temporary providers such as WeChat or WeCom remain available later; stale recent entries are removed safely instead of crashing. Android also remembers normalized reading progress per document and restores it when the same source or cached Recent entry is opened again.
 
 ## Features
 
@@ -108,6 +108,7 @@ On iPhone and iPad, Local Markdown Preview opens Markdown and plain-text files f
 | Scroll continuity | Preview and source edit preserve normalized reading progress when their document heights differ. |
 | Start screen | Empty launches show Open File and local recent files, so the app is useful before anything is loaded. |
 | Mobile open | iOS opens Markdown from Files and the share sheet; Android can open Markdown from Files, WeChat, WeCom, and Android share sheets. |
+| Android continue reading | Reopening the same source or cached Recent document restores its last normalized reading position. |
 | Drag and drop | Drop a Markdown file into the window and it opens immediately. |
 | CLI open | `md-preview path/to/file.md` opens directly from a shell. |
 | Find in preview | `Cmd/Ctrl+F` opens a compact search bar for the rendered document. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -90,7 +90,7 @@ MD Preview 支持通过拖拽、打开对话框、最近文件或命令行打开
 
 在 Finder 文件夹空白处右键，可以新建 Markdown、文本、JSON、HTML，复制目录路径，或在终端打开。选择**新建 Markdown**后会自动避开重名，并直接在 MD Preview 源码编辑器里打开新文件。
 
-iPhone 和 iPad 上，Local Markdown Preview 可以从“文件”和 iOS 分享面板打开 Markdown / 文本文件。Android 上，MD Preview 会出现在 Markdown 文件的“打开方式”和分享流程中。Recent 文件会缓存到应用私有目录，从微信、企业微信等临时来源打开过的文档后续也能继续打开；如果条目失效，会安全移除而不是闪退。
+iPhone 和 iPad 上，Local Markdown Preview 可以从“文件”和 iOS 分享面板打开 Markdown / 文本文件。Android 上，MD Preview 会出现在 Markdown 文件的“打开方式”和分享流程中。Recent 文件会缓存到应用私有目录，从微信、企业微信等临时来源打开过的文档后续也能继续打开；如果条目失效，会安全移除而不是闪退。Android 还会按文档记录归一化阅读进度，再次打开同一来源或 Recent 缓存时自动恢复。
 
 ## 功能
 
@@ -108,6 +108,7 @@ iPhone 和 iPad 上，Local Markdown Preview 可以从“文件”和 iOS 分享
 | 滚动连续 | 预览和源码高度不同时，切换仍按归一化阅读进度恢复位置。 |
 | 启动首页 | 空白启动时显示打开文件和本机最近文件，没加载文档也有明确入口。 |
 | 手机端打开 | iOS 支持从“文件”和分享面板打开 Markdown；Android 支持从文件管理器、微信、企业微信和系统分享面板打开 Markdown。 |
+| Android 继续阅读 | 再次打开同一来源或 Recent 缓存文档时，恢复上次归一化阅读位置。 |
 | 拖拽打开 | 把 Markdown 文件拖进窗口即可打开。 |
 | 命令行打开 | `md-preview path/to/file.md` 直接从 shell 打开。 |
 | 预览搜索 | `Cmd/Ctrl+F` 打开轻量搜索栏，在渲染后的文档内查找。 |

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -5,7 +5,7 @@
 ## Scope
 
 - iOS: 原生 UIKit + `WKWebView`，声明 Markdown 文档类型，支持系统文档选择器和 Open In。
-- Android: 原生 Java + `WebView`，声明 `ACTION_VIEW` / `ACTION_SEND` intent filter，支持参与 Markdown 默认打开器选择。
+- Android: 原生 Java + `WebView`，声明 `ACTION_VIEW` / `ACTION_SEND` intent filter，支持参与 Markdown 默认打开器选择，并按文档保存归一化阅读位置供下次继续阅读。
 - 渲染层: `mobile/shared` 中的一份离线 HTML/JS/CSS，首屏只加载 `marked` 和 highlight.js，KaTeX/Mermaid 按文档内容延迟加载。
 
 ## Build

--- a/mobile/RELEASE_CHECKLIST.md
+++ b/mobile/RELEASE_CHECKLIST.md
@@ -7,6 +7,7 @@
 - Android: install `mobile/android/app/build/outputs/apk/debug/app-debug.apk` on a real phone and open `.md`, `.markdown`, `.mdown`, `.mkd` files from Files, WeChat, and WeCom.
 - Android: long-press a Markdown file, choose "Open with", select MD Preview, then verify the system offers it again as the default handler.
 - Android: verify `ACTION_SEND` from WeChat/WeCom share sheet opens the same document.
+- Android: scroll a long document, close the app, then reopen the same source and its cached Recent entry; both should restore the last normalized reading position.
 - iOS: install on a real iPhone, open Markdown files from Files, WeChat, and WeCom via the share sheet / Open In.
 - iOS: verify the app appears for `.md`, `.markdown`, `.mdown`, and `.mkd`; iOS does not allow silently forcing a default handler.
 - Both: test UTF-8, UTF-8 with BOM, UTF-16 LE/BE, large documents, tables wider than the screen, local images, external links, KaTeX, and Mermaid.

--- a/mobile/android/app/src/main/java/app/mdpreview/mobile/MainActivity.java
+++ b/mobile/android/app/src/main/java/app/mdpreview/mobile/MainActivity.java
@@ -46,6 +46,7 @@ public final class MainActivity extends Activity {
     private static final int OPEN_DOCUMENT_REQUEST = 7;
     private static final String RECENT_PREFS = "recent";
     private static final String RECENT_FILES = "files";
+    private static final String READING_POSITION_PREFS = "reading_positions";
     private static final String[] MARKDOWN_MIME_TYPES = new String[] {
         "text/markdown",
         "text/x-markdown",
@@ -90,6 +91,12 @@ public final class MainActivity extends Activity {
         if (uri != null) {
             openUri(uri);
         }
+    }
+
+    @Override
+    protected void onPause() {
+        evaluate("window.MDPreview && window.MDPreview.flushReadingPosition();");
+        super.onPause();
     }
 
     @Override
@@ -191,11 +198,13 @@ public final class MainActivity extends Activity {
             byte[] bytes = readBytes(uri);
             String markdown = decodeMarkdown(bytes);
             String name = displayName(uri);
+            String documentKey = documentKey(uri);
             JSONObject payload = new JSONObject();
             payload.put("markdown", markdown);
             payload.put("name", name);
             payload.put("baseHref", "file".equals(uri.getScheme()) ? baseHref(uri) : "");
-            saveRecent(name, bytes);
+            addReadingPosition(payload, documentKey);
+            saveRecent(name, bytes, documentKey);
             evaluate("window.MDPreview && window.MDPreview.render(" + payload + ");");
         } catch (IOException | RuntimeException | JSONException e) {
             if (fromRecent) {
@@ -426,6 +435,24 @@ public final class MainActivity extends Activity {
         return getSharedPreferences(RECENT_PREFS, MODE_PRIVATE);
     }
 
+    private SharedPreferences readingPositionPrefs() {
+        return getSharedPreferences(READING_POSITION_PREFS, MODE_PRIVATE);
+    }
+
+    private String documentKey(Uri uri) {
+        return "uri:" + uri.normalizeScheme();
+    }
+
+    private String recentDocumentKey(JSONObject item, String id) {
+        String documentKey = item.optString("documentKey");
+        return documentKey.isEmpty() ? "recent:" + id : documentKey;
+    }
+
+    private void addReadingPosition(JSONObject payload, String documentKey) throws JSONException {
+        payload.put("documentKey", documentKey);
+        payload.put("readingProgress", readingPositionPrefs().getFloat(documentKey, 0.0f));
+    }
+
     private JSONArray recentFiles() {
         String raw = recentPrefs().getString(RECENT_FILES, "[]");
         try {
@@ -443,7 +470,7 @@ public final class MainActivity extends Activity {
         return directory;
     }
 
-    private void saveRecent(String name, byte[] bytes) {
+    private void saveRecent(String name, byte[] bytes, String documentKey) {
         String displayName = cleanRecentName(name);
         String fileName = UUID.randomUUID() + "-" + safeRecentFileName(displayName);
         File file = new File(recentDirectory(), fileName);
@@ -459,6 +486,7 @@ public final class MainActivity extends Activity {
             JSONObject current = new JSONObject();
             current.put("id", fileName);
             current.put("name", displayName);
+            current.put("documentKey", documentKey);
             next.put(current);
             for (int i = 0; i < previous.length(); i++) {
                 JSONObject item = previous.optJSONObject(i);
@@ -566,6 +594,7 @@ public final class MainActivity extends Activity {
             payload.put("markdown", decodeMarkdown(bytes));
             payload.put("name", cleanRecentName(item.optString("name")));
             payload.put("baseHref", "");
+            addReadingPosition(payload, recentDocumentKey(item, id));
             evaluate("window.MDPreview && window.MDPreview.render(" + payload + ");");
         } catch (IOException | RuntimeException | JSONException e) {
             removeRecentId(id);
@@ -601,6 +630,18 @@ public final class MainActivity extends Activity {
         @JavascriptInterface
         public void openRecent(String uri) {
             runOnUiThread(() -> openRecentId(uri));
+        }
+
+        @JavascriptInterface
+        public void saveReadingPosition(String documentKey, double progress) {
+            if (documentKey == null
+                || documentKey.isEmpty()
+                || Double.isNaN(progress)
+                || Double.isInfinite(progress)) {
+                return;
+            }
+            float normalized = (float) Math.max(0.0, Math.min(1.0, progress));
+            readingPositionPrefs().edit().putFloat(documentKey, normalized).apply();
         }
     }
 }

--- a/mobile/scripts/verify-mobile-renderer.mjs
+++ b/mobile/scripts/verify-mobile-renderer.mjs
@@ -19,6 +19,15 @@ page.on('pageerror', error => errors.push(error.message));
 page.on('console', message => {
   if (message.type() === 'error') errors.push(message.text());
 });
+await page.addInitScript(() => {
+  window.__readingPositionSaves = [];
+  window.MDPreviewAndroid = {
+    getRecent() {},
+    saveReadingPosition(documentKey, progress) {
+      window.__readingPositionSaves.push({ documentKey, progress });
+    }
+  };
+});
 
 await page.goto(preview);
 await page.waitForLoadState('domcontentloaded');
@@ -85,6 +94,76 @@ const result = await page.evaluate((searchHits) => ({
   bad: window.__bad === 1
 }), searchHitCount);
 
+await page.emulateMedia({ media: 'screen', colorScheme: 'light' });
+const readingMarkdown = Array.from(
+  { length: 140 },
+  (_, index) => `## Reading section ${index + 1}\n\nParagraph ${index + 1} keeps the fixture scrollable.`
+).join('\n\n');
+await page.evaluate(markdown => {
+  window.MDPreview.render({
+    name: 'reading-position.md',
+    documentKey: 'uri:content://fixture/reading-position.md',
+    readingProgress: 0.62,
+    markdown
+  });
+}, readingMarkdown);
+await page.waitForFunction(() => {
+  const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+  return maxScroll > 0 && Math.abs(window.scrollY / maxScroll - 0.62) < 0.025;
+});
+await page.evaluate(() => {
+  const extra = document.createElement('div');
+  extra.innerHTML = Array.from(
+    { length: 20 },
+    (_, index) => `<h2>Deferred section ${index + 1}</h2><p>Late rendered content.</p>`
+  ).join('');
+  document.getElementById('preview').appendChild(extra);
+});
+await page.waitForFunction(() => {
+  const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+  return maxScroll > 0 && Math.abs(window.scrollY / maxScroll - 0.62) < 0.025;
+});
+await page.evaluate(() => {
+  window.dispatchEvent(new PointerEvent('pointerdown'));
+  const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+  window.scrollTo(0, maxScroll * 0.37);
+});
+await page.waitForTimeout(300);
+const savedReadingPosition = await page.evaluate(() => {
+  const saves = window.__readingPositionSaves;
+  return saves[saves.length - 1];
+});
+await page.evaluate(({ markdown, progress }) => {
+  window.scrollTo(0, 0);
+  window.MDPreview.render({
+    name: 'reading-position.md',
+    documentKey: 'uri:content://fixture/reading-position.md',
+    readingProgress: progress,
+    markdown
+  });
+}, { markdown: readingMarkdown, progress: savedReadingPosition.progress });
+await page.waitForFunction(expected => {
+  const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+  return maxScroll > 0 && Math.abs(window.scrollY / maxScroll - expected) < 0.025;
+}, savedReadingPosition.progress);
+const reopenedReadingProgress = await page.evaluate(() => {
+  const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+  return maxScroll ? window.scrollY / maxScroll : 0;
+});
+await page.evaluate(() => {
+  window.MDPreview.render({
+    name: 'short.md',
+    documentKey: 'uri:content://fixture/short.md',
+    readingProgress: 0.8,
+    markdown: '# Short document'
+  });
+  window.MDPreview.flushReadingPosition();
+});
+const shortDocument = await page.evaluate(() => ({
+  scrollY: window.scrollY,
+  saved: window.__readingPositionSaves[window.__readingPositionSaves.length - 1]
+}));
+
 await browser.close();
 
 if (errors.length) {
@@ -126,6 +205,19 @@ if (result.printTopbarDisplay !== 'none' ||
 }
 if (result.bad) {
   throw new Error('javascript: link executed');
+}
+if (savedReadingPosition.documentKey !== 'uri:content://fixture/reading-position.md' ||
+    Math.abs(savedReadingPosition.progress - 0.37) > 0.025 ||
+    Math.abs(reopenedReadingProgress - savedReadingPosition.progress) > 0.025) {
+  throw new Error(`Reading position persistence failed: ${JSON.stringify({
+    savedReadingPosition,
+    reopenedReadingProgress
+  })}`);
+}
+if (shortDocument.scrollY !== 0 ||
+    shortDocument.saved.documentKey !== 'uri:content://fixture/short.md' ||
+    shortDocument.saved.progress !== 0) {
+  throw new Error(`Short-document reading position failed: ${JSON.stringify(shortDocument)}`);
 }
 
 console.log('[mobile-renderer] OK');

--- a/mobile/shared/mobile-preview.js
+++ b/mobile/shared/mobile-preview.js
@@ -18,6 +18,10 @@
   var currentHit = -1;
   var recentItems = [];
   var searchOriginScroll = null;
+  var currentDocumentKey = '';
+  var readingPositionTimer = null;
+  var readingPositionRestore = null;
+  var readingPositionRestoreSeq = 0;
   var assetBase = new URL('.', window.location.href).href;
   var ICON_OPEN = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 14 1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6A2 2 0 0 1 18.45 20H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"/></svg>';
   var ICON_SEARCH = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>';
@@ -119,11 +123,84 @@
     });
   }
 
+  function normalizedReadingProgress() {
+    var root = document.documentElement;
+    var maxScroll = Math.max(0, root.scrollHeight - window.innerHeight);
+    if (!maxScroll) return 0;
+    return Math.max(0, Math.min(1, (window.scrollY || 0) / maxScroll));
+  }
+
+  function flushReadingPosition() {
+    if (readingPositionTimer !== null) {
+      clearTimeout(readingPositionTimer);
+      readingPositionTimer = null;
+    }
+    if (!currentDocumentKey ||
+        !window.MDPreviewAndroid ||
+        !window.MDPreviewAndroid.saveReadingPosition) return;
+    window.MDPreviewAndroid.saveReadingPosition(
+      currentDocumentKey,
+      normalizedReadingProgress()
+    );
+  }
+
+  function scheduleReadingPositionSave() {
+    if (!currentDocumentKey) return;
+    if (readingPositionTimer !== null) clearTimeout(readingPositionTimer);
+    readingPositionTimer = setTimeout(flushReadingPosition, 180);
+  }
+
+  function cancelReadingPositionRestore() {
+    readingPositionRestoreSeq++;
+    if (readingPositionRestore) {
+      readingPositionRestore.disconnect();
+      readingPositionRestore = null;
+    }
+  }
+
+  function restoreReadingPosition(progress) {
+    cancelReadingPositionRestore();
+    var target = Number(progress);
+    if (!Number.isFinite(target)) target = 0;
+    target = Math.max(0, Math.min(1, target));
+    var restoreSeq = readingPositionRestoreSeq;
+    var restore = function() {
+      if (restoreSeq !== readingPositionRestoreSeq) return;
+      var maxScroll = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+      window.scrollTo(0, Math.round(maxScroll * target));
+    };
+
+    restore();
+    requestAnimationFrame(restore);
+    [80, 240, 720].forEach(function(delay) {
+      setTimeout(restore, delay);
+    });
+    if (window.MutationObserver) {
+      readingPositionRestore = new MutationObserver(function() {
+        requestAnimationFrame(restore);
+      });
+      readingPositionRestore.observe(previewEl, { childList: true, subtree: true });
+      Array.prototype.forEach.call(previewEl.querySelectorAll('img'), function(image) {
+        if (image.complete) return;
+        image.addEventListener('load', restore, { once: true });
+        image.addEventListener('error', restore, { once: true });
+      });
+      setTimeout(function() {
+        if (restoreSeq === readingPositionRestoreSeq) cancelReadingPositionRestore();
+      }, 2000);
+    }
+  }
+
   function render(payload) {
+    flushReadingPosition();
+    cancelReadingPositionRestore();
     closeSearch();
     var markdown = payload && payload.markdown ? String(payload.markdown) : '';
     var name = payload && payload.name ? String(payload.name) : 'Untitled.md';
     var baseHref = payload && payload.baseHref ? String(payload.baseHref) : '';
+    currentDocumentKey = payload && payload.documentKey ? String(payload.documentKey) : '';
+    var readingProgress = payload && payload.readingProgress !== undefined ?
+      payload.readingProgress : 0;
     var flags = featureFlags(markdown);
     document.body.classList.remove('empty');
     titleEl.textContent = name;
@@ -131,6 +208,7 @@
     if (baseHref) baseEl.setAttribute('href', baseHref);
     else baseEl.removeAttribute('href');
     previewEl.innerHTML = window.marked ? window.marked.parse(markdown) : markdown;
+    restoreReadingPosition(readingProgress);
     idle(function() {
       if (window.hljs && window.hljs.highlightAll) window.hljs.highlightAll();
       enhance(flags);
@@ -338,14 +416,28 @@
 
   searchClose.addEventListener('click', closeSearch);
 
+  window.addEventListener('scroll', scheduleReadingPositionSave, { passive: true });
+  window.addEventListener('pagehide', flushReadingPosition);
+  document.addEventListener('visibilitychange', function() {
+    if (document.visibilityState === 'hidden') flushReadingPosition();
+  });
+  ['touchstart', 'pointerdown', 'wheel', 'keydown'].forEach(function(eventName) {
+    window.addEventListener(eventName, cancelReadingPositionRestore, { passive: true });
+  });
+
   window.MDPreview = {
     render: render,
     setRecent: renderRecent,
+    flushReadingPosition: flushReadingPosition,
     setEmpty: function() {
+      flushReadingPosition();
+      cancelReadingPositionRestore();
+      currentDocumentKey = '';
       closeSearch();
       document.body.classList.add('empty');
       titleEl.textContent = 'MD Preview';
       previewEl.innerHTML = '';
+      window.scrollTo(0, 0);
     }
   };
 


### PR DESCRIPTION
## Summary

- persist normalized reading progress per Android document in a dedicated `SharedPreferences` store
- keep the source document key on cached Recent entries so reopening either path resumes at the same place
- debounce scroll saves, flush before backgrounding/document switches, and restore after deferred renderer/image layout changes
- add Playwright regression coverage and update Android/mobile documentation

## Verification

- `node mobile/scripts/verify-mobile-renderer.mjs` — passed (repeated 3 times)
- `gradle :app:assembleDebug --no-daemon` — passed
- `git diff --check` — passed
- `gradle :app:lintDebug --no-daemon` — reaches lint, then reports the existing `AppLinkUrlError` for the unchanged `file://` intent filter at `AndroidManifest.xml:56`; no new reading-position lint error

## Covered scenarios

1. Reopening the same long document restores its saved normalized position.
2. Cached Recent entries reuse the source document position.
3. Short/non-scrollable documents clamp safely to the top.
4. Deferred content growth preserves the target progress until the reader interacts.
